### PR TITLE
:sparkles: Completed feature #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+6.0.1 / 2019-11-13
+===================
+- Completed feature #16 - added logging when finding elements
+
 6.0.0 / 2019-10-31
 ===================
 - Fixed Bug #22 - context.browser can be both a browser name and a webdriver object

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="6.0.0",
+    version="6.0.1",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from hamcrest import assert_that, equal_to
 from selenium.webdriver.common.by import By
 from uitestcore.page_element import PageElement
@@ -40,6 +41,18 @@ def test_elements():
 
     assert_that(elements[0].info, equal_to("elements found by 'id' using value 'test-id'"),
                 "An element list should be found")
+
+
+def test_elements_logs_out_info():
+    driver = MockDriver()
+    logger = MagicMock()
+    find = Finder(driver, logger)
+
+    find.elements(PageElement(By.ID, "test-id"))
+
+    assert_that(logger.info.call_count, equal_to(2), "Two messages should have been logged")
+    logger.info.assert_any_call("Looking for elements matching PageElement id='test-id'")
+    logger.info.assert_any_call("Found 1 element(s)")
 
 
 def test_element():

--- a/tests/unit/test_interactor.py
+++ b/tests/unit/test_interactor.py
@@ -247,7 +247,7 @@ def test_switch_to_original_window():
 
 def test_switch_to_frame():
     mock_driver = MagicMock(name="driver")
-    finder = Finder(mock_driver, "logger")
+    finder = Finder(mock_driver, MagicMock(name="logger"))
     interrogator = Interrogator(mock_driver, finder, "logger")
     waiter = Waiter(mock_driver, finder, "logger")
     test_interactor = Interactor(mock_driver, finder, interrogator, waiter, "logger")

--- a/uitestcore/finder.py
+++ b/uitestcore/finder.py
@@ -25,7 +25,10 @@ class Finder:
         :param page_element: PageElement instance representing the element
         :return: list of matching WebElements
         """
-        return self.driver.find_elements(page_element.locator_type, page_element.locator_value)
+        self.logger.info(f"Looking for elements matching {page_element}")
+        elements = self.driver.find_elements(page_element.locator_type, page_element.locator_value)
+        self.logger.info(f"Found {len(elements)} element(s)")
+        return elements
 
     @auto_log(__name__)
     def element(self, page_element):


### PR DESCRIPTION
## Description
Added logging to elements function in Finder to give information about the selector being used and the number of elements found. To try this out you just need to enable logging e.g. in config file: "logging_flag": true

This will give output such as:
`INFO:automation-ui:Looking for elements matching PageElement id='my_id'`
`INFO:automation-ui:Found 1 element(s)`

This is logged out whenever an element needs to be checked or interacted with because all the relevant functions use elements(). This can be installed from TestPyPI: https://test.pypi.org/project/uitestcore/
`pip install -i https://test.pypi.org/simple/ uitestcore`

## Related Issue
#16 