### PR TITLE
Add axe reporting functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+7.0.2.20220114 / 2022-01-14
+===================
+- Added Axe reporting functionality
+- Added ability to run non-headless tests on MacOS using Chrome 
+- Updated invalid characters to be replaced in 'remove_invalid_characters' function 
+
 7.0.2 / 2021-11-29
 ===================
 - Updated required packages to the latest versions in setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-7.0.2.20220114 / 2022-01-14
+8.0.0/ 2022-03-15
 ===================
 - Added Axe reporting functionality
 - Added ability to run non-headless tests on MacOS using Chrome 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-8.0.0/ 2022-03-15
+8.0.0 / 2022-03-15
 ===================
 - Added Axe reporting functionality
 - Added ability to run non-headless tests on MacOS using Chrome 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-    pytest --cov=uitestcore --cov-fail-under=90 --cov-report term-missing --junitxml='reports/junit/unit-tests.xml'
+    pytest --cov=uitestcore --cov-fail-under=95 --cov-report term-missing --junitxml='reports/junit/unit-tests.xml'
   displayName: 'Unit tests with coverage'
 
 - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-    pytest --cov=uitestcore --cov-fail-under=95 --cov-report term-missing --junitxml='reports/junit/unit-tests.xml'
+    pytest --cov=uitestcore --cov-fail-under=90 --cov-report term-missing --junitxml='reports/junit/unit-tests.xml'
   displayName: 'Unit tests with coverage'
 
 - task: PublishTestResults@2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="7.0.2",
+    version="7.0.2.20220114",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="7.2.20220204",
+    version="7.2.20220209",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="7.2.20220209",
+    version="7.2.20220210",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="7.0.2.20220114",
+    version="7.2.20220203",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="7.2.20220210",
+    version="8.0.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="7.2.20220203",
+    version="7.2.20220204",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/unit/utilities/test_browser_handler.py
+++ b/tests/unit/utilities/test_browser_handler.py
@@ -226,6 +226,13 @@ def test_move_screenshots_to_folder(mock_move, mock_path_exists, mock_listdir):
     mock_move.assert_any_call("screenshots/test4.png", "screenshots/test_folder")
 
 
+def test_run_axe_accessibility_report_no_axe_instance():
+    context = MockContext()
+
+    assert_that(calling(BrowserHandler.run_axe_accessibility_report).with_args(context), raises(AttributeError),
+                "An AttributeError should be raised when there is no context.axe value")
+
+
 @mock.patch("uitestcore.utilities.browser_handler.open_chrome")
 @mock.patch("uitestcore.utilities.browser_handler.start_browserstack")
 @mock.patch("uitestcore.utilities.browser_handler.open_firefox")
@@ -278,11 +285,11 @@ def test_open_browser_not_supported(mock_open_firefox, mock_start_browserstack, 
     check_mocked_functions_not_called(mock_open_chrome, mock_start_browserstack, mock_open_firefox)
 
 
-@mock.patch("os.name", "nt")
+@mock.patch("platform.system", return_value="Windows")
 @mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
 @mock.patch("selenium.webdriver.ChromeOptions")
 @mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
-def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_chrome):
+def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_chrome, mock_platform):
     context = MockContext()
 
     open_chrome(context)
@@ -291,11 +298,24 @@ def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_
     check_mocked_functions_not_called(mock_chromeoptions)
 
 
-@mock.patch("os.name", "ubuntu")
+@mock.patch("platform.system", return_value="Darwin")
+@mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
+@mock.patch("selenium.webdriver.ChromeOptions")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_chrome_mac_os(mock_set_browser_size, mock_chromeoptions, mock_chrome, mock_platform):
+    context = MockContext()
+
+    open_chrome(context)
+
+    check_mocked_functions_called(mock_chrome, mock_set_browser_size)
+    check_mocked_functions_not_called(mock_chromeoptions)
+
+
+@mock.patch("platform.system", return_value="Linux")
 @mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
 @mock.patch("selenium.webdriver.ChromeOptions.add_argument")
 @mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
-def test_open_chrome_non_windows_os(mock_set_browser_size, mock_add_argument, mock_chrome):
+def test_open_chrome_non_windows_os(mock_set_browser_size, mock_add_argument, mock_chrome, mock_platform):
     context = MockContext()
 
     open_chrome(context)

--- a/tests/unit/utilities/test_browser_handler.py
+++ b/tests/unit/utilities/test_browser_handler.py
@@ -291,6 +291,19 @@ def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_
     check_mocked_functions_not_called(mock_chromeoptions)
 
 
+@mock.patch("os.name", "posix")
+@mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
+@mock.patch("selenium.webdriver.ChromeOptions")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_chrome_mac_os(mock_set_browser_size, mock_chromeoptions, mock_chrome):
+    context = MockContext()
+
+    open_chrome(context)
+
+    check_mocked_functions_called(mock_chrome, mock_set_browser_size)
+    check_mocked_functions_not_called(mock_chromeoptions)
+
+
 @mock.patch("os.name", "ubuntu")
 @mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
 @mock.patch("selenium.webdriver.ChromeOptions.add_argument")

--- a/tests/unit/utilities/test_browser_handler.py
+++ b/tests/unit/utilities/test_browser_handler.py
@@ -291,19 +291,6 @@ def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_
     check_mocked_functions_not_called(mock_chromeoptions)
 
 
-@mock.patch("os.name", "posix")
-@mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
-@mock.patch("selenium.webdriver.ChromeOptions")
-@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
-def test_open_chrome_mac_os(mock_set_browser_size, mock_chromeoptions, mock_chrome):
-    context = MockContext()
-
-    open_chrome(context)
-
-    check_mocked_functions_called(mock_chrome, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_chromeoptions)
-
-
 @mock.patch("os.name", "ubuntu")
 @mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
 @mock.patch("selenium.webdriver.ChromeOptions.add_argument")

--- a/tests/unit/utilities/test_config.py
+++ b/tests/unit/utilities/test_config.py
@@ -1,9 +1,12 @@
+import io
+from unittest import mock
 from hamcrest import assert_that, equal_to
 from uitestcore.utilities.config_handler import parse_config_data
 
 
 class MockContext:
-    def __init__(self, maximize_browser=None, logging_flag=None):
+    def __init__(self, url=None, maximize_browser=None, logging_flag=None):
+        self.url = ""
         self.maximize_browser = maximize_browser
         self.logging_flag = logging_flag
         self.browser = ""
@@ -52,3 +55,27 @@ def test_parse_config_data_sets_browser_type():
     parse_config_data(context)
 
     assert_that(context.browser, equal_to("chrome"), "Expected browser type was not found")
+
+
+def test_parse_config_data_sets_base_url():
+    userdata = {
+        "base_url": "https://www.test.com"
+    }
+    context = MockContext()
+    context.config = MockConfig(userdata)
+
+    parse_config_data(context)
+
+    assert_that(context.url, equal_to("https://www.test.com"), "Expected url value was not found")
+
+
+@mock.patch('sys.stdout', new_callable=io.StringIO)
+def test_parse_config_data_no_command_line_params(mock_stdout):
+    userdata = {}
+    context = MockContext()
+    context.config = MockConfig(userdata)
+
+    parse_config_data(context)
+
+    assert_that(mock_stdout.getvalue(), equal_to("No Command line Params detected, using Config file values\n"),
+                "Unexpected print string")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -98,7 +98,7 @@ class BrowserHandler:
     @staticmethod
     def run_axe_accessibility_report(context):
         """
-        write blurb here
+        Run Axe accessibility report on the current page and output a file containing violations if found
         :param context: the test context instance
         The context must include an instance of Axe (context.axe) and the Scenario name (context.scenario_name)
         """

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -5,6 +5,7 @@ from selenium import webdriver
 from uitestcore.utilities.config_handler import parse_config_data
 from uitestcore.utilities.datetime_handler import get_current_datetime
 from uitestcore.utilities.string_util import remove_invalid_characters
+from pathlib import Path
 
 SCREENSHOTS_PATH = "screenshots"
 
@@ -93,6 +94,26 @@ class BrowserHandler:
         for file in files:
             if file.endswith(".png"):
                 shutil.move(source + file, destination)
+
+    @staticmethod
+    def run_axe_accessibility_report(context):
+        # Inject axe-core javascript into page
+        context.axe.inject()
+        # Run axe accessibility checks
+        results = context.axe.run()
+        # Checks for violations and adds them to a text file if they exist
+        if len(results["violations"]) > 0:
+            Path("axe_reports/violations").mkdir(parents=True, exist_ok=True)
+            with open("axe_reports/violations/violations.txt", "a+") as violations_file:
+                violations_file.write(f"{'=' * 75}\n\n\n"
+                                      f"Scenario name: {context.scenario_name}\n"
+                                      f"URL: {results['url']}\n"
+                                      f"Page title: {context.axe.selenium.title}\n"
+                                      f"Timestamp: {results['timestamp']}\n"
+                                      f"Browser: {context.axe.selenium.capabilities['browserName']} "
+                                      f"{context.axe.selenium.capabilities['browserVersion']}\n"
+                                      f"axe-core version: {results['testEngine']['version']}\n\n"
+                                      f"{context.axe.report(results['violations'])}")
 
 
 def open_browser(context):

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -103,7 +103,9 @@ class BrowserHandler:
         :param context: the test context instance
         The context must include an instance of Axe (context.axe) and the Scenario name (context.scenario_name)
         """
-        if not context.scenario_name:
+        try:
+            context.scenario_name
+        except AttributeError:
             context.scenario_name = "No Scenario name passed to function"
         if not context.axe:
             raise AttributeError()

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -157,9 +157,6 @@ def open_chrome(context):
     if os.name == 'nt':
         context.browser = webdriver.Chrome(executable_path=r"./browser_executables/chromedriver.exe")
 
-    elif os.name == 'posix':
-        context.browser = webdriver.Chrome(executable_path=r"./browser_executables/chromedriver")
-
     else:
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_argument("--no-sandbox")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -157,6 +157,9 @@ def open_chrome(context):
     if os.name == 'nt':
         context.browser = webdriver.Chrome(executable_path=r"./browser_executables/chromedriver.exe")
 
+    elif os.name == 'posix':
+        context.browser = webdriver.Chrome(executable_path=r"./browser_executables/chromedriver")
+
     else:
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_argument("--no-sandbox")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -97,6 +97,21 @@ class BrowserHandler:
 
     @staticmethod
     def run_axe_accessibility_report(context):
+        """
+        write blurb here
+        :param context: the test context instance
+        The context must include an instance of Axe (context.axe) and the Scenario name (context.scenario_name)
+        """
+        try:
+            context.scenario_name
+        except AttributeError:
+            context.scenario_name = "No Scenario name passed to function"
+        try:
+            context.axe
+        except AttributeError:
+            print("\nNo instance of Axe assigned to test context")
+            return
+
         # Inject axe-core javascript into page
         context.axe.inject()
         # Run axe accessibility checks

--- a/uitestcore/utilities/string_util.py
+++ b/uitestcore/utilities/string_util.py
@@ -23,8 +23,10 @@ def remove_invalid_characters(input_string):
     :param input_string: the string which needs to be altered
     :return: edited string
     """
-    return input_string.replace(" ", "_").replace(",", "").replace("'", "")\
-                       .replace("\n", "").replace("/", "_").replace(":", "")
+    return input_string.replace(" ", "_").replace(",", "").replace(".", "") \
+        .replace("\n", "").replace("/", "_").replace("*", "").replace(":", "") \
+        .replace("?", "").replace('"', '').replace("'", "").replace("|", "_") \
+        .replace("<", "_").replace(">", "_")
 
 
 def decode_url_string(input_string):


### PR DESCRIPTION
## Description
Added Axe reporting functionality to run accessibility tests and generate a report. 
Added ability to run non-headless tests on MacOS using Chrome. 
Updated invalid characters to be replaced in 'remove_invalid_characters' function.

## Motivation and Context
Allows NHSuk testers to automate accessibility testing using the [Axe Tool](https://www.deque.com/axe/). This will generate a report locally and in Azure which will allow the frontend devs to make improvements.
A user with a Mac can now use this framework the same way as a Windows user. The Chromedriver file needs to be placed in the browser_executables folder.
Additional special characters are replaced. The new characters to be replaced were added to an exiting function.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] Verified in Test PyPi
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)