### PR TITLE
add support for passing extra browser options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+9.1.0 / 2022-07-22
+===================
+- Added support for setting extra arguments against the webdriver browser options
+    - These can be given as a list set to context.browser_options
+- Geckodriver executable path removed for Linux
+
 9.0.0 / 2022-07-15
 ===================
 - Upgrade to Selenium 4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="9.0.0",
+    version="9.1.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/unit/utilities/test_browser_handler.py
+++ b/tests/unit/utilities/test_browser_handler.py
@@ -22,10 +22,11 @@ class MockBrowser:
 
 
 class MockContext:
-    def __init__(self, maximize_browser=None, logging_flag=None, implicit_wait=0):
+    def __init__(self, maximize_browser=None, logging_flag=None, implicit_wait=0, browser_options=None):
         self.maximize_browser = maximize_browser
         self.logging_flag = logging_flag
         self.browser = MockBrowser()
+        self.browser_options = browser_options
         self.logger = MockLogger()
         self.implicit_wait = implicit_wait
 
@@ -305,6 +306,21 @@ def test_open_browser_not_supported(mock_open_firefox, mock_start_browserstack, 
 
 @mock.patch("platform.system", return_value="Windows")
 @mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
+@mock.patch("selenium.webdriver.ChromeOptions.add_argument")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_chrome_windows_os_options(mock_set_browser_size, mock_add_argument, mock_chrome, mock_platform):
+    context = MockContext()
+    context.browser_options = ["--headless"]
+
+    open_chrome(context)
+
+    assert_that(mock_add_argument.call_count, equal_to(1), "Incorrect number of arguments added to chrome")
+    mock_add_argument.assert_any_call("--headless")
+    check_mocked_functions_called(mock_chrome, mock_set_browser_size)
+
+
+@mock.patch("platform.system", return_value="Windows")
+@mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
 @mock.patch("selenium.webdriver.ChromeOptions")
 @mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
 def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_chrome, mock_platform):
@@ -312,8 +328,7 @@ def test_open_chrome_windows_os(mock_set_browser_size, mock_chromeoptions, mock_
 
     open_chrome(context)
 
-    check_mocked_functions_called(mock_chrome, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_chromeoptions)
+    check_mocked_functions_called(mock_chrome, mock_set_browser_size, mock_chromeoptions)
 
 
 @mock.patch("platform.system", return_value="Darwin")
@@ -325,8 +340,26 @@ def test_open_chrome_mac_os(mock_set_browser_size, mock_chromeoptions, mock_chro
 
     open_chrome(context)
 
+    check_mocked_functions_called(mock_chrome, mock_set_browser_size, mock_chromeoptions)
+
+
+@mock.patch("platform.system", return_value="Linux")
+@mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
+@mock.patch("selenium.webdriver.ChromeOptions.add_argument")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_chrome_non_windows_os_options(mock_set_browser_size, mock_add_argument, mock_chrome, mock_platform):
+    context = MockContext()
+    context.browser_options = ["--ignore-certificate-errors"]
+
+    open_chrome(context)
+
+    assert_that(mock_add_argument.call_count, equal_to(5), "Incorrect number of arguments added to chrome")
+    mock_add_argument.assert_any_call("--no-sandbox")
+    mock_add_argument.assert_any_call("--window-size=1420,1080")
+    mock_add_argument.assert_any_call("--headless")
+    mock_add_argument.assert_any_call("--disable-gpu")
+    mock_add_argument.assert_any_call("--ignore-certificate-errors")
     check_mocked_functions_called(mock_chrome, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_chromeoptions)
 
 
 @mock.patch("platform.system", return_value="Linux")
@@ -348,6 +381,21 @@ def test_open_chrome_non_windows_os(mock_set_browser_size, mock_add_argument, mo
 
 @mock.patch("platform.system", return_value="Windows")
 @mock.patch("selenium.webdriver.Edge", side_effect=lambda **kwargs: "mock_edge")
+@mock.patch("selenium.webdriver.EdgeOptions.add_argument")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_edge_windows_os_options(mock_set_browser_size, mock_add_argument, mock_edge, mock_platform):
+    context = MockContext()
+    context.browser_options = ["--headless"]
+
+    open_edge(context)
+
+    assert_that(mock_add_argument.call_count, equal_to(1), "Incorrect number of arguments added to edge")
+    mock_add_argument.assert_any_call("--headless")
+    check_mocked_functions_called(mock_edge, mock_set_browser_size)
+
+
+@mock.patch("platform.system", return_value="Windows")
+@mock.patch("selenium.webdriver.Edge", side_effect=lambda **kwargs: "mock_edge")
 @mock.patch("selenium.webdriver.EdgeOptions")
 @mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
 def test_open_edge_windows_os(mock_set_browser_size, mock_edgeoptions, mock_edge, mock_platform):
@@ -355,8 +403,7 @@ def test_open_edge_windows_os(mock_set_browser_size, mock_edgeoptions, mock_edge
 
     open_edge(context)
 
-    check_mocked_functions_called(mock_edge, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_edgeoptions)
+    check_mocked_functions_called(mock_edge, mock_set_browser_size, mock_edgeoptions)
 
 
 @mock.patch("platform.system", return_value="Darwin")
@@ -368,8 +415,7 @@ def test_open_edge_mac_os(mock_set_browser_size, mock_edgeoptions, mock_edge, mo
 
     open_edge(context)
 
-    check_mocked_functions_called(mock_edge, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_edgeoptions)
+    check_mocked_functions_called(mock_edge, mock_set_browser_size, mock_edgeoptions)
 
 
 @mock.patch("platform.system", return_value="Linux")
@@ -391,6 +437,21 @@ def test_open_edge_non_windows_os(mock_set_browser_size, mock_add_argument, mock
 
 @mock.patch("platform.system", return_value="Windows")
 @mock.patch("selenium.webdriver.Firefox", side_effect=lambda **kwargs: "mock_firefox")
+@mock.patch("selenium.webdriver.FirefoxOptions.add_argument")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_firefox_windows_os_options(mock_set_browser_size, mock_add_argument, mock_firefox, mock_platform):
+    context = MockContext()
+    context.browser_options = ["--headless"]
+
+    open_firefox(context)
+
+    assert_that(mock_add_argument.call_count, equal_to(1), "Incorrect number of arguments added to firefox")
+    mock_add_argument.assert_any_call("--headless")
+    check_mocked_functions_called(mock_firefox, mock_set_browser_size)
+
+
+@mock.patch("platform.system", return_value="Windows")
+@mock.patch("selenium.webdriver.Firefox", side_effect=lambda **kwargs: "mock_firefox")
 @mock.patch("selenium.webdriver.FirefoxOptions")
 @mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
 def test_open_firefox_windows_os(mock_set_browser_size, mock_firefoxoptions, mock_firefox, mock_platform):
@@ -398,8 +459,7 @@ def test_open_firefox_windows_os(mock_set_browser_size, mock_firefoxoptions, moc
 
     open_firefox(context)
 
-    check_mocked_functions_called(mock_firefox, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_firefoxoptions)
+    check_mocked_functions_called(mock_firefox, mock_set_browser_size, mock_firefoxoptions)
 
 
 @mock.patch("platform.system", return_value="Darwin")
@@ -411,8 +471,7 @@ def test_open_firefox_mac_os(mock_set_browser_size, mock_firefoxoptions, mock_fi
 
     open_firefox(context)
 
-    check_mocked_functions_called(mock_firefox, mock_set_browser_size)
-    check_mocked_functions_not_called(mock_firefoxoptions)
+    check_mocked_functions_called(mock_firefox, mock_set_browser_size, mock_firefoxoptions)
 
 
 @mock.patch("platform.system", return_value="Linux")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -162,23 +162,24 @@ def open_chrome(context):
     Open the Chrome browser
     :param context: the test context instance
     """
+    chrome_options = webdriver.ChromeOptions()
+
     if platform.system() == 'Windows':
         chromedriver_path = ChromeService(executable_path=r"./browser_executables/chromedriver.exe")
-        context.browser = webdriver.Chrome(service=chromedriver_path)
-
     elif platform.system() == 'Darwin':
         chromedriver_path = ChromeService(executable_path=r"./browser_executables/chromedriver")
-        context.browser = webdriver.Chrome(service=chromedriver_path)
-
     else:
-        chrome_options = webdriver.ChromeOptions()
+        chromedriver_path = ChromeService()
         chrome_options.add_argument("--no-sandbox")
         chrome_options.add_argument("--window-size=1420,1080")
         chrome_options.add_argument("--headless")
         chrome_options.add_argument("--disable-gpu")
 
-        # No need to specify the executable as we're using one installed via pip in Dockerfile
-        context.browser = webdriver.Chrome(options=chrome_options)
+    # Add config browser options to chrome options
+    for option in context.browser_options or []:
+        chrome_options.add_argument(option)
+
+    context.browser = webdriver.Chrome(options=chrome_options, service=chromedriver_path)
 
     BrowserHandler.set_browser_size(context)
 
@@ -188,23 +189,24 @@ def open_edge(context):
     Open the Edge browser
     :param context: the test context instance
     """
+    edge_options = webdriver.EdgeOptions()
+
     if platform.system() == 'Windows':
         edgedriver_path = EdgeService(executable_path=r"./browser_executables/msedgedriver.exe")
-        context.browser = webdriver.Edge(service=edgedriver_path)
-
     elif platform.system() == 'Darwin':
         edgedriver_path = EdgeService(executable_path=r"./browser_executables/msedgedriver")
-        context.browser = webdriver.Edge(service=edgedriver_path)
-
     else:
-        edge_options = webdriver.EdgeOptions()
+        edgedriver_path = EdgeService()
         edge_options.add_argument("--no-sandbox")
         edge_options.add_argument("--window-size=1420,1080")
         edge_options.add_argument("--headless")
         edge_options.add_argument("--disable-gpu")
 
-        # No need to specify the executable as we're using one installed via pip in Dockerfile
-        context.browser = webdriver.Edge(options=edge_options)
+    # Add config browser options to edge options
+    for option in context.browser_options or []:
+        edge_options.add_argument(option)
+
+    context.browser = webdriver.Edge(options=edge_options, service=edgedriver_path)
 
     BrowserHandler.set_browser_size(context)
 
@@ -214,21 +216,21 @@ def open_firefox(context):
     Open the Firefox browser
     :param context: the test context instance
     """
+    firefox_options = webdriver.FirefoxOptions()
+
     if platform.system() == 'Windows':
         geckodriver_path = FirefoxService(executable_path=r"./browser_executables/geckodriver.exe")
-        context.browser = webdriver.Firefox(service=geckodriver_path)
-
     elif platform.system() == 'Darwin':
         geckodriver_path = FirefoxService(executable_path=r"./browser_executables/geckodriver")
-        context.browser = webdriver.Firefox(service=geckodriver_path)
-
     else:
-        firefox_options = webdriver.FirefoxOptions()
+        geckodriver_path = FirefoxService()
         firefox_options.add_argument("--headless")
 
-        # The Firefox driver (geckodriver) must be located in the "firefox" folder when running in Docker
-        geckodriver_path = FirefoxService(executable_path=r"firefox/geckodriver")
-        context.browser = webdriver.Firefox(service=geckodriver_path, options=firefox_options)
+    # Add config browser options to firefox options
+    for option in context.browser_options or []:
+        firefox_options.add_argument(option)
+
+    context.browser = webdriver.Firefox(options=firefox_options, service=geckodriver_path)
 
     BrowserHandler.set_browser_size(context)
 


### PR DESCRIPTION
## Description
- Added support for setting extra arguments against the webdriver browser options
    - These can be given as a list set to context.browser_options
- Geckodriver executable path removed for Linux

## Checklist
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)