### PR TITLE
update attachments api to support build runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /dist
 /uitestcore.egg-info
 **/__pycache__/
+
+.coverage
+unit-tests.xml
+geckodriver.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+10.0.0 / 2022-08-01
+===================
+- Added support for attaching files to build runs (previously this was only release runs)
+    - The `attach_files()` method has been refactored out to `attach_files_release()` and `attach_files_build()`. These new methods **no longer accept cli system arguments** for the release/build id and access token being used. Instead these parameters should be given directly from the calling code.
+    - Updated to the latest API version for Azure GET requests
+
 9.1.0 / 2022-07-22
 ===================
 - Added support for setting extra arguments against the webdriver browser options

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This package is located on PyPI: https://pypi.org/project/uitestcore/ - it can b
 The easiest way to include this package in your project is by adding it to your requirements.txt. 
 Here is an example of the line which should be added to this file, we recommend using a specific version but it's your call: 
 
-`uitestcore==3.3.0`
+`uitestcore==10.0.0`
 
 ### Deployment to PyPI
 PyPI deployment is configured in the release pipeline of the NHS.UK Azure Devops project. Any changes merged into master will be automatically deployed to PyPI, and any changes pushed to a branch starting with "test/" will be automatically deployed to TestPyPI.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.0.202208011",
+    version="10.0.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.0.0-20220801-1",
+    version="10.0.202208011",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="9.1.0",
+    version="10.0.0-20220801-1",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/unit/utilities/test_attachments_api.py
+++ b/tests/unit/utilities/test_attachments_api.py
@@ -12,7 +12,7 @@ class MockResponse:
         self.mode = mode
 
     def json(self):
-        if self.mode == "get_run_ids":
+        if self.mode == "get_run_ids_from_response":
             return {
                 "value": [
                     {"id": 1},
@@ -77,78 +77,50 @@ def test_print_response_info_does_not_print_when_response_has_no_title(mock_prin
 
 
 @mock.patch("builtins.print")
-def test_parse_parameters_returns_valid_params(mock_print):
-    args = ["unused_arg", "test-release-id", "test-auth-token"]
-
-    params = parse_parameters(args)
-
-    assert_that(params, equal_to(("test-release-id", "test-auth-token")), "Incorrect parameters returned")
-    expected_message = "The release ID is: test-release-id"
-    mock_print.assert_called_with(expected_message)
-
-
-@mock.patch("builtins.print")
-def test_parse_parameters_handles_invalid_number_of_arguments(mock_print):
-    args = ["test1", "test2"]
-
-    params = parse_parameters(args)
-
-    assert_that(params, equal_to(None), "No parameters should be returned when arguments are invalid")
-    expected_message = "##vso[task.logissue type=error]Unable to parse required parameters - " \
-                       "ensure they are passed correctly. Expected release ID and auth token."
-    mock_print.assert_called_with(expected_message)
-
-
-@mock.patch("builtins.print")
-@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 200, "get_run_ids"))
-def test_get_run_ids_performs_the_correct_request(mock_get, _mock_print):
-    get_run_ids(100, "test-url", "test-token")
+@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 200, "get_run_ids_from_response"))
+def test_get_run_ids_by_release_performs_the_correct_request(mock_get, _mock_print):
+    get_run_ids_by_release(100, "test-url", "test-token")
 
     check_mocked_functions_called(mock_get)
     request_args = mock_get.call_args
 
     assert_that(request_args[0][0], equal_to("test-url"), "request_url incorrect")
     assert_that(request_args[1]["params"]["releaseIds"], equal_to(100), "releaseIds incorrect")
-    assert_that(request_args[1]["params"]["api-version"], equal_to("5.0"), "api-version for GET incorrect")
+    assert_that(request_args[1]["params"]["api-version"], equal_to("6.0"), "api-version for GET incorrect")
     assert_that(request_args[1]["auth"][1], equal_to("test-token"), "Auth token incorrect")
 
 
 @mock.patch("builtins.print")
-@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 200, "get_run_ids"))
-def test_get_run_ids_uses_the_correct_min_and_max_dates_in_its_response(mock_get, _mock_print):
-    get_run_ids(100, "test-url", "test-token")
+@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 200, "get_run_ids_from_response"))
+def test_get_run_ids_by_build_performs_the_correct_request(mock_get, _mock_print):
+    get_run_ids_by_build(100, "test-url", "test-token")
 
     check_mocked_functions_called(mock_get)
     request_args = mock_get.call_args
 
-    expected_date_time = datetime.datetime.now()
-    actual_date_time = request_args[1]["params"]["maxLastUpdatedDate"]
-    time_difference = (actual_date_time - expected_date_time).total_seconds()
-    assert_that(time_difference, less_than(2), "maxLastUpdatedDate incorrect")
-
-    expected_date_time = get_date_altered_by_days(-1, datetime.datetime.now())
-    actual_date_time = request_args[1]["params"]["minLastUpdatedDate"]
-    time_difference = (actual_date_time - expected_date_time).total_seconds()
-    assert_that(time_difference, less_than(2), "minLastUpdatedDate incorrect")
+    assert_that(request_args[0][0], equal_to("test-url"), "request_url incorrect")
+    assert_that(request_args[1]["params"]["buildIds"], equal_to(100), "buildIds incorrect")
+    assert_that(request_args[1]["params"]["api-version"], equal_to("6.0"), "api-version for GET incorrect")
+    assert_that(request_args[1]["auth"][1], equal_to("test-token"), "Auth token incorrect")
 
 
 @mock.patch("builtins.print")
-@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 200, "get_run_ids"))
-def test_get_run_ids_returns_ids_when_request_succeeds(mock_get, _mock_print):
-    run_ids = get_run_ids(100, "test-url", "test-token")
+@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 200, "get_run_ids_from_response"))
+def test_get_run_ids_by_release_returns_ids_when_request_succeeds(mock_get, _mock_print):
+    run_ids = get_run_ids_by_release(100, "test-url", "test-token")
 
     check_mocked_functions_called(mock_get)
     assert_that(run_ids, equal_to([1, 2, 3]), "Incorrect run IDs returned")
 
 
-@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 400, "get_run_ids"))
+@mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 400, "get_run_ids_from_response"))
 @mock.patch("builtins.print")
-def test_get_run_ids_returns_no_ids_when_request_fails(mock_print, mock_get):
-    run_ids = get_run_ids(100, "test-url", "test-token")
+def test_get_run_ids_by_release_returns_no_ids_when_request_fails(mock_print, mock_get):
+    run_ids = get_run_ids_by_release(100, "test-url", "test-token")
 
     check_mocked_functions_called(mock_get, mock_print)
     assert_that(run_ids, equal_to([]), "Run IDs should not be returned when the request failed")
-    mock_print.assert_called_with("##vso[task.logissue type=error]Could not get run IDs for release 100")
+    mock_print.assert_called_with("##vso[task.logissue type=error]Could not get run IDs for release/build 100")
 
 
 @mock.patch("requests.get", side_effect=lambda *args, **kwargs: MockResponse("", 400, "get_failed_tests"))
@@ -181,7 +153,7 @@ def test_get_failed_tests_performs_the_correct_request(mock_get, _mock_print):
     request_args = mock_get.call_args
 
     assert_that(request_args[0][0], equal_to("test-url/100/results"), "request_url incorrect")
-    assert_that(request_args[1]["params"]["api-version"], equal_to("5.0"), "api-version for GET incorrect")
+    assert_that(request_args[1]["params"]["api-version"], equal_to("6.0"), "api-version for GET incorrect")
     assert_that(request_args[1]["auth"][1], equal_to("test-token"), "Auth token incorrect")
 
 
@@ -201,108 +173,133 @@ def test_attach_files_fails_when_passed_no_parameters(_mock_print):
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: None)
-def test_attach_files_fails_when_there_are_no_run_ids(mock_get_run_ids, _mock_print):
-    result = attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: None)
+def test_attach_files_release_fails_when_there_are_no_run_ids(mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
-    check_mocked_functions_called(mock_get_run_ids)
+    check_mocked_functions_called(mock_get_run_ids_from_response)
     assert_that(result, equal_to(1), "Result should be a failure when there are no run IDs")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
-@mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: None)
-def test_attach_files_fails_when_there_are_no_failed_tests(mock_get_failed_tests, mock_get_run_ids, _mock_print):
-    result = attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: None)
+def test_attach_files_build_fails_when_there_are_no_run_ids(mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_build("test-org", "test-project", "screenshots", "100", "test-token")
 
-    check_mocked_functions_called(mock_get_failed_tests, mock_get_run_ids)
+    check_mocked_functions_called(mock_get_run_ids_from_response)
+    assert_that(result, equal_to(1), "Result should be a failure when there are no run IDs")
+
+
+@mock.patch("builtins.print")
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: None)
+def test_attach_files_fails_when_there_are_no_failed_tests(mock_get_failed_tests, mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
+
+    check_mocked_functions_called(mock_get_failed_tests, mock_get_run_ids_from_response)
     assert_that(result, equal_to(1), "Result should be a failure when there are no failed tests")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
 @mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: None)
 @mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"],
                                                                                                 [11, 101, "test2"]])
-def test_attach_files_fails_when_there_are_no_files(mock_get_failed_tests, mock_listdir, mock_get_run_ids, _mock_print):
-    result = attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+def test_attach_files_fails_when_there_are_no_files(mock_get_failed_tests, mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
-    check_mocked_functions_called(mock_listdir, mock_get_failed_tests, mock_get_run_ids)
+    check_mocked_functions_called(mock_listdir, mock_get_failed_tests, mock_get_run_ids_from_response)
     assert_that(result, equal_to(1), "Result should be a failure when there are no files")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
 @mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: ["test1", "test2"])
 @mock.patch("uitestcore.utilities.attachments_api.get_file_base64", side_effect=lambda *args: None)
 @mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"],
                                                                                                 [11, 101, "test2"]])
 def test_attach_files_fails_when_there_base64_conversion_fails(mock_get_failed_tests, mock_get_file_base64,
-                                                               mock_listdir, mock_get_run_ids, _mock_print):
-    result = attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+                                                               mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
-    check_mocked_functions_called(mock_get_failed_tests, mock_get_file_base64, mock_listdir, mock_get_run_ids)
+    check_mocked_functions_called(mock_get_failed_tests, mock_get_file_base64, mock_listdir, mock_get_run_ids_from_response)
     assert_that(result, equal_to(1), "Result should be a failure when base64 conversion fails")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
 @mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: ["file1"])
 @mock.patch("uitestcore.utilities.attachments_api.get_file_base64", side_effect=lambda *args: None)
 @mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"]])
 def test_attach_files_gets_the_base64_of_the_correct_file(mock_get_failed_tests, mock_get_file_base64,
-                                                          mock_listdir, mock_get_run_ids, _mock_print):
-    attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+                                                          mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
-    check_mocked_functions_called(mock_get_failed_tests, mock_listdir, mock_get_run_ids)
+    check_mocked_functions_called(mock_get_failed_tests, mock_listdir, mock_get_run_ids_from_response)
     mock_get_file_base64.assert_called_with("screenshots/test1/file1")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
 @mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: ["test1", "test2"])
 @mock.patch("uitestcore.utilities.attachments_api.get_file_base64", side_effect=lambda *args: b"test-base64-string")
 @mock.patch("requests.post", side_effect=lambda *args, **kwargs: MockResponse("", 400))
 @mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"],
                                                                                                 [11, 101, "test2"]])
 def test_attach_files_fails_when_the_request_fails(mock_get_failed_tests, mock_post, mock_get_file_base64,
-                                                   mock_listdir, mock_get_run_ids, _mock_print):
-    result = attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+                                                   mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
     check_mocked_functions_called(mock_get_failed_tests, mock_post, mock_get_file_base64,
-                                  mock_listdir, mock_get_run_ids)
+                                  mock_listdir, mock_get_run_ids_from_response)
     assert_that(result, equal_to(1), "Result should be a failure when the request fails")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
 @mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: ["test1", "test2"])
 @mock.patch("uitestcore.utilities.attachments_api.get_file_base64", side_effect=lambda *args: b"test-base64-string")
 @mock.patch("requests.post", side_effect=lambda *args, **kwargs: MockResponse("", 200))
 @mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"],
                                                                                                 [11, 101, "test2"]])
-def test_attach_files_succeeds(mock_get_failed_tests, mock_post, mock_get_file_base64,
-                               mock_listdir, mock_get_run_ids, _mock_print):
-    result = attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+def test_attach_files_release_succeeds(mock_get_failed_tests, mock_post, mock_get_file_base64,
+                               mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
     check_mocked_functions_called(mock_get_failed_tests, mock_post, mock_get_file_base64,
-                                  mock_listdir, mock_get_run_ids)
+                                  mock_listdir, mock_get_run_ids_from_response)
     assert_that(result, equal_to(0), "Result should be a success when everything works")
 
 
 @mock.patch("builtins.print")
-@mock.patch("uitestcore.utilities.attachments_api.get_run_ids", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
+@mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: ["test1", "test2"])
+@mock.patch("uitestcore.utilities.attachments_api.get_file_base64", side_effect=lambda *args: b"test-base64-string")
+@mock.patch("requests.post", side_effect=lambda *args, **kwargs: MockResponse("", 200))
+@mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"],
+                                                                                                [11, 101, "test2"]])
+def test_attach_files_build_succeeds(mock_get_failed_tests, mock_post, mock_get_file_base64,
+                               mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    result = attach_files_build("test-org", "test-project", "screenshots", "100", "test-token")
+
+    check_mocked_functions_called(mock_get_failed_tests, mock_post, mock_get_file_base64,
+                                  mock_listdir, mock_get_run_ids_from_response)
+    assert_that(result, equal_to(0), "Result should be a success when everything works")
+
+
+@mock.patch("builtins.print")
+@mock.patch("uitestcore.utilities.attachments_api.get_run_ids_from_response", side_effect=lambda *args: [10, 11])
 @mock.patch("uitestcore.utilities.attachments_api.listdir", side_effect=lambda *args: ["test1", "test2"])
 @mock.patch("uitestcore.utilities.attachments_api.get_file_base64", side_effect=lambda *args: b"test-base64-string")
 @mock.patch("requests.post", side_effect=lambda *args, **kwargs: MockResponse("", 200))
 @mock.patch("uitestcore.utilities.attachments_api.get_failed_tests", side_effect=lambda *args: [[10, 100, "test1"],
                                                                                                 [11, 101, "test2"]])
 def test_attach_files_performs_the_correct_request(mock_get_failed_tests, mock_post, mock_get_file_base64,
-                                                   mock_listdir, mock_get_run_ids, _mock_print):
-    attach_files("test-org", "test-project", "screenshots", [None, "100", "test-token"])
+                                                   mock_listdir, mock_get_run_ids_from_response, _mock_print):
+    attach_files_release("test-org", "test-project", "screenshots", "100", "test-token")
 
     check_mocked_functions_called(mock_get_failed_tests, mock_post, mock_get_file_base64,
-                                  mock_listdir, mock_get_run_ids)
+                                  mock_listdir, mock_get_run_ids_from_response)
     request_args = mock_post.call_args
 
     assert_that(request_args[0][0], equal_to("https://dev.azure.com/test-org/test-project/_apis/"

--- a/uitestcore/utilities/attachments_api.py
+++ b/uitestcore/utilities/attachments_api.py
@@ -26,8 +26,11 @@ def attach_files_release(organisation, project, attachments_path, release_id, ac
     :param access_token: access token to authenticate with the azure api
     :return: integer: a return value of 0 indicates success, 1 means that any file could not be attached
     """
+
+    # Set the URL for the required API
     request_url = f"https://dev.azure.com/{organisation}/{project}/_apis/test/runs"
 
+    # Get the run IDs for the given release
     run_ids = get_run_ids_by_release(release_id, request_url, access_token)
     if not run_ids:
         print_azure_error(f"No test runs found for release {release_id}")
@@ -47,8 +50,11 @@ def attach_files_build(organisation, project, attachments_path, build_id, access
     :param access_token: access token to authenticate with the azure api
     :return: integer: a return value of 0 indicates success, 1 means that any file could not be attached
     """
+
+    # Set the URL for the required API
     request_url = f"https://dev.azure.com/{organisation}/{project}/_apis/test/runs"
 
+    # Get the run IDs for the given build
     run_ids = get_run_ids_by_build(build_id, request_url, access_token)
     if not run_ids:
         print_azure_error(f"No test runs found for build {build_id}")
@@ -67,6 +73,8 @@ def attach_files(run_ids, request_url, access_token, attachment_file_path):
     :param attachment_file_path: the file path to the directory containing the files to attach
     :return: integer: a return value of 0 indicates success, 1 means that any file could not be attached
     """
+
+    # Get the list of failed tests
     failed_tests = get_failed_tests(run_ids, request_url, access_token)
 
     if not failed_tests:
@@ -152,7 +160,7 @@ def get_run_ids_by_release(release_id, request_url, access_token):
 def get_run_ids_by_build(build_id, request_url, access_token):
     """
     Get the test run IDs for the given build ID - each feature will have a unique run ID
-    :param release_id: the build ID from Azure DevOps
+    :param build_id: the build ID from Azure DevOps
     :param request_url: the url for the azure api
     :param access_token: access token to authenticate with the azure api
     :return: list of run IDs which were found
@@ -197,7 +205,7 @@ def get_run_ids_from_response(query_id, response):
 
 def print_response_info(response):
     """
-    Prints additional infomration from the title of the response e.g. to show when the token has expired
+    Prints additional information from the title of the response e.g. to show when the token has expired
     :param response: the response object returned by the request
     """
     if response.content:
@@ -211,7 +219,7 @@ def get_failed_tests(run_ids, request_url, access_token):
     Get the required details of the failed tests from the given runs
     :param run_ids: list of run IDs to query
     :param request_url: the url for the azure api
-    :param access_token: the ID number of the release from Azure DevOps
+    :param access_token: access token to authenticate with the azure api
     :return: list of test details in the format: (run ID, test ID, test name)
     """
     failed_tests = []

--- a/uitestcore/utilities/attachments_api.py
+++ b/uitestcore/utilities/attachments_api.py
@@ -12,41 +12,62 @@ from xml.etree.ElementTree import fromstring
 import requests
 from uitestcore.utilities.string_util import remove_invalid_characters
 
-AZURE_API_VERSION_GET = "5.0"
+AZURE_API_VERSION_GET = "6.0"
 AZURE_API_VERSION_POST = "5.0-preview.1"
 
 
-def attach_files(organisation, project, attachment_file_path, args):
+def attach_files_release(organisation, project, attachments_path, release_id, access_token):
     """
-    Get the details of the failed tests from a given release and attach the files using Microsoft API calls
     The organisation and project names can be found in the project URL e.g. dev.azure.com/organisation/project
     :param organisation: the Azure organisation name
     :param project: the Azure project name
-    :param attachment_file_path: the file path to the directory containing the files to attach
-    :param args: sys.argv which should contain the release ID and auth token
+    :param attachments_path: the file path to the directory containing the files to attach
+    :param release_id: the release id to search for test runs in
+    :param access_token: access token to authenticate with the azure api
     :return: integer: a return value of 0 indicates success, 1 means that any file could not be attached
     """
-    # Get the release ID and auth token from the passed arguments
-    params = parse_parameters(args)
-    if not params:
-        return 1
-    release_id = params[0]
-    auth_token = params[1]
-
-    # Set the URL for the required API
     request_url = f"https://dev.azure.com/{organisation}/{project}/_apis/test/runs"
 
-    # Get the run IDs for the given release
-    run_ids = get_run_ids(release_id, request_url, auth_token)
-
+    run_ids = get_run_ids_by_release(release_id, request_url, access_token)
     if not run_ids:
         print_azure_error(f"No test runs found for release {release_id}")
         return 1
-
     print(f"Run IDs found for release {release_id}: {run_ids}")
 
-    # Get the list of failed tests
-    failed_tests = get_failed_tests(run_ids, request_url, auth_token)
+    return attach_files(run_ids, request_url, access_token, attachments_path)
+
+
+def attach_files_build(organisation, project, attachments_path, build_id, access_token):
+    """
+    The organisation and project names can be found in the project URL e.g. dev.azure.com/organisation/project
+    :param organisation: the Azure organisation name
+    :param project: the Azure project name
+    :param attachments_path: the file path to the directory containing the files to attach
+    :param build_id: the build id to search for test runs in
+    :param access_token: access token to authenticate with the azure api
+    :return: integer: a return value of 0 indicates success, 1 means that any file could not be attached
+    """
+    request_url = f"https://dev.azure.com/{organisation}/{project}/_apis/test/runs"
+
+    run_ids = get_run_ids_by_build(build_id, request_url, access_token)
+    if not run_ids:
+        print_azure_error(f"No test runs found for build {build_id}")
+        return 1
+    print(f"Run IDs found for build {build_id}: {run_ids}")
+
+    return attach_files(run_ids, request_url, access_token, attachments_path)
+
+
+def attach_files(run_ids, request_url, access_token, attachment_file_path):
+    """
+    Get the details of the failed tests from a given set of run ids and attach the files using Microsoft Azure API calls
+    :param run_ids: list of run ids to search for failed tests within and attach files to
+    :param request_url: the url for the azure api
+    :param access_token: access token to authenticate with the azure api
+    :param attachment_file_path: the file path to the directory containing the files to attach
+    :return: integer: a return value of 0 indicates success, 1 means that any file could not be attached
+    """
+    failed_tests = get_failed_tests(run_ids, request_url, access_token)
 
     if not failed_tests:
         return 1
@@ -87,7 +108,7 @@ def attach_files(organisation, project, attachment_file_path, args):
             response = requests.post(
                 f"{request_url}/{run_id}/Results/{test_case_result_id}/attachments",
                 params={"api-version": AZURE_API_VERSION_POST},
-                auth=("", auth_token),
+                auth=("", access_token),
                 headers={"Content-Type": "application/json"},
                 data=json.dumps({
                     "attachmentType": "GeneralAttachment",
@@ -105,31 +126,12 @@ def attach_files(organisation, project, attachment_file_path, args):
     return return_value
 
 
-def parse_parameters(args):
-    """
-    Parse the release ID and auth token from the provided arguments
-    :param args: sys.argv which should contain the release ID and auth token (args[0] is not used)
-    :return: tuple containing the two parameters or None if there was an error
-    """
-    try:
-        params = args[1], args[2]
-
-    except IndexError:
-        print_azure_error("Unable to parse required parameters - ensure they are passed correctly. "
-                          "Expected release ID and auth token.")
-        return None
-
-    else:
-        print(f"The release ID is: {params[0]}")
-        return params
-
-
-def get_run_ids(release_id, request_url, auth_token):
+def get_run_ids_by_release(release_id, request_url, access_token):
     """
     Get the test run IDs for the given release ID - each feature will have a unique run ID
     :param release_id: the release ID from Azure DevOps
-    :param request_url: the URL for the Microsoft API
-    :param auth_token: the ID number of the release from Azure DevOps
+    :param request_url: the url for the azure api
+    :param access_token: access token to authenticate with the azure api
     :return: list of run IDs which were found
     """
     max_last_updated_date = datetime.datetime.now()
@@ -142,13 +144,45 @@ def get_run_ids(release_id, request_url, auth_token):
                 "releaseIds": release_id,
                 "api-version": AZURE_API_VERSION_GET
                 },
-        auth=("", auth_token)
+        auth=("", access_token)
     )
+    return get_run_ids_from_response(release_id, response)
 
-    print(f"Get run IDs for release {release_id} - response {response.status_code}")
+
+def get_run_ids_by_build(build_id, request_url, access_token):
+    """
+    Get the test run IDs for the given build ID - each feature will have a unique run ID
+    :param release_id: the build ID from Azure DevOps
+    :param request_url: the url for the azure api
+    :param access_token: access token to authenticate with the azure api
+    :return: list of run IDs which were found
+    """
+    max_last_updated_date = datetime.datetime.now()
+    min_last_updated_date = max_last_updated_date - datetime.timedelta(days=1)
+
+    response = requests.get(
+        request_url,
+        params={"minLastUpdatedDate": min_last_updated_date,
+                "maxLastUpdatedDate": max_last_updated_date,
+                "buildIds": build_id,
+                "api-version": AZURE_API_VERSION_GET
+                },
+        auth=("", access_token)
+    )
+    return get_run_ids_from_response(build_id, response)
+
+
+def get_run_ids_from_response(query_id, response):
+    """
+    Get the run ids from response body of queried api
+    :param query_id: the release/build ID from Azure DevOps
+    :param response: the response of the queried api to extract run ids from
+    :return: list of run IDs which were found
+    """
+    print(f"Get run IDs - response {response.status_code}")
 
     if not response.status_code == 200:
-        print_azure_error(f"Could not get run IDs for release {release_id}")
+        print_azure_error(f"Could not get run IDs for release/build {query_id}")
         print_response_info(response)
         return []
 
@@ -172,12 +206,12 @@ def print_response_info(response):
             print(info)
 
 
-def get_failed_tests(run_ids, request_url, auth_token):
+def get_failed_tests(run_ids, request_url, access_token):
     """
     Get the required details of the failed tests from the given runs
     :param run_ids: list of run IDs to query
-    :param request_url: the URL for the Microsoft API
-    :param auth_token: the ID number of the release from Azure DevOps
+    :param request_url: the url for the azure api
+    :param access_token: the ID number of the release from Azure DevOps
     :return: list of test details in the format: (run ID, test ID, test name)
     """
     failed_tests = []
@@ -186,7 +220,7 @@ def get_failed_tests(run_ids, request_url, auth_token):
         response = requests.get(
             request_url + f"/{run_id}/results",
             params={"api-version": AZURE_API_VERSION_GET},
-            auth=("", auth_token)
+            auth=("", access_token)
         )
 
         print(f"Get failed tests for run ID {run_id} - response {response.status_code}")


### PR DESCRIPTION
## Description
- Added support for attaching files to build runs (previously this was only release runs)
    - The `attach_files()` method has been refactored out to `attach_files_release()` and `attach_files_build()`. These new methods **no longer accept cli system arguments** for the release/build id and access token being used. Instead these parameters should be given directly from the calling code.
    - Updated to the latest API version for Azure GET requests

## Checklist
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)