### PR TITLE
You can now set the browser via command line parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+10.0.1 / 2022-08-19
+===================
+- Bug fix - You can now set the browser via command line parameters 
+- If setting browser via command line, using _-Dbrowser=chrome_ will set context.browser_name to "chrome"
+
 10.0.0 / 2022-08-01
 ===================
 - Added support for attaching files to build runs (previously this was only release runs)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.0.0",
+    version="10.0.1",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/unit/utilities/test_config.py
+++ b/tests/unit/utilities/test_config.py
@@ -54,7 +54,7 @@ def test_parse_config_data_sets_browser_type():
 
     parse_config_data(context)
 
-    assert_that(context.browser, equal_to("chrome"), "Expected browser type was not found")
+    assert_that(context.browser_name, equal_to("chrome"), "Expected browser type was not found")
 
 
 def test_parse_config_data_sets_base_url():

--- a/uitestcore/utilities/config_handler.py
+++ b/uitestcore/utilities/config_handler.py
@@ -32,7 +32,7 @@ def parse_config_data(context):
                     continue
 
             elif key.lower() == "browser":
-                context.browser = value
+                context.browser_name = value
 
     else:
         print("No Command line Params detected, using Config file values")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Bug fix - You can now set the browser via command line parameters
If setting browser via command line, using _-Dbrowser=chrome_ will set context.browser_name to "chrome"

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)