### PR TITLE
context.browser_options does not need to be defined if not in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+10.1.0 / 2022-11-02
+===================
+- No longer necessary to define the 'context.browser_options' variable in _environment.py_ if you do not intend on using 'browser_options' in the config
+- Updated required packages to the latest versions in setup.py
+- Updated required packages to the latest versions in azure-pipelines.yml
+
 10.0.1 / 2022-08-19
 ===================
 - Bug fix - You can now set the browser via command line parameters 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,9 @@ steps:
 - script: |
     python -m pip install --upgrade pip
     pip install -e .
-    pip install pytest==7.1.2
-    pip install pytest-cov==3.0.0
-    pip install pylint==2.14.5
+    pip install pytest==7.2.0
+    pip install pytest-cov==4.0.0
+    pip install pylint==2.15.5
     pip install wheel
   displayName: 'Install dependencies'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.0.1",
+    version="10.1.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -13,15 +13,15 @@ setup(
     homepage="https://github.com/nhsuk/ui-test-core/",
     packages=["uitestcore", "uitestcore.utilities"],
     install_requires=[
-        "certifi==2022.6.15",
+        "certifi==2022.9.24",
         "chardet==5.0.0",
-        "idna==3.3",
-        "pyhamcrest==2.0.3",
+        "idna==3.4",
+        "pyhamcrest==2.0.4",
         "python-dateutil==2.8.2",
         "requests==2.28.1",
         "selenium==4.3.0",
         "six==1.16.0",
-        "urllib3==1.26.10"
+        "urllib3==1.26.12"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/unit/utilities/test_browser_handler.py
+++ b/tests/unit/utilities/test_browser_handler.py
@@ -1,3 +1,4 @@
+import io
 from datetime import datetime
 from unittest import mock
 from hamcrest import equal_to, raises, calling
@@ -304,6 +305,22 @@ def test_open_browser_not_supported(mock_open_firefox, mock_start_browserstack, 
     check_mocked_functions_not_called(mock_open_chrome, mock_open_edge, mock_start_browserstack, mock_open_firefox)
 
 
+@mock.patch('sys.stdout', new_callable=io.StringIO)
+@mock.patch("platform.system", return_value="Windows")
+@mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_chrome_browser_options_not_defined(mock_set_browser_size, mock_chrome, mock_platform, mock_stdout):
+    context = MockContext()
+    delattr(context, "browser_options")
+
+    open_chrome(context)
+
+    assert_that(mock_stdout.getvalue(), equal_to(
+        "No config browser_options detected and the variable 'context.browser_options' is not defined\n"),
+                "Unexpected print string")
+    check_mocked_functions_called(mock_chrome, mock_set_browser_size)
+
+
 @mock.patch("platform.system", return_value="Windows")
 @mock.patch("selenium.webdriver.Chrome", side_effect=lambda **kwargs: "mock_chrome")
 @mock.patch("selenium.webdriver.ChromeOptions.add_argument")
@@ -379,6 +396,22 @@ def test_open_chrome_non_windows_os(mock_set_browser_size, mock_add_argument, mo
     check_mocked_functions_called(mock_chrome, mock_set_browser_size)
 
 
+@mock.patch('sys.stdout', new_callable=io.StringIO)
+@mock.patch("platform.system", return_value="Darwin")
+@mock.patch("selenium.webdriver.Edge", side_effect=lambda **kwargs: "mock_edge")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_edge_browser_options_not_defined(mock_set_browser_size, mock_edge, mock_platform, mock_stdout):
+    context = MockContext()
+    delattr(context, "browser_options")
+
+    open_edge(context)
+
+    assert_that(mock_stdout.getvalue(), equal_to(
+        "No config browser_options detected and the variable 'context.browser_options' is not defined\n"),
+                "Unexpected print string")
+    check_mocked_functions_called(mock_edge, mock_set_browser_size)
+
+
 @mock.patch("platform.system", return_value="Windows")
 @mock.patch("selenium.webdriver.Edge", side_effect=lambda **kwargs: "mock_edge")
 @mock.patch("selenium.webdriver.EdgeOptions.add_argument")
@@ -433,6 +466,22 @@ def test_open_edge_non_windows_os(mock_set_browser_size, mock_add_argument, mock
     mock_add_argument.assert_any_call("--headless")
     mock_add_argument.assert_any_call("--disable-gpu")
     check_mocked_functions_called(mock_edge, mock_set_browser_size)
+
+
+@mock.patch('sys.stdout', new_callable=io.StringIO)
+@mock.patch("platform.system", return_value="Windows")
+@mock.patch("selenium.webdriver.Firefox", side_effect=lambda **kwargs: "mock_firefox")
+@mock.patch("uitestcore.utilities.browser_handler.BrowserHandler.set_browser_size")
+def test_open_firefox_browser_options_not_defined(mock_set_browser_size, mock_firefox, mock_platform, mock_stdout):
+    context = MockContext()
+    delattr(context, "browser_options")
+
+    open_firefox(context)
+
+    assert_that(mock_stdout.getvalue(), equal_to(
+        "No config browser_options detected and the variable 'context.browser_options' is not defined\n"),
+                "Unexpected print string")
+    check_mocked_functions_called(mock_firefox, mock_set_browser_size)
 
 
 @mock.patch("platform.system", return_value="Windows")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -176,8 +176,7 @@ def open_chrome(context):
         chrome_options.add_argument("--disable-gpu")
 
     # Add config browser options to chrome options
-    for option in context.browser_options or []:
-        chrome_options.add_argument(option)
+    chrome_options = add_browser_options(context, chrome_options)
 
     context.browser = webdriver.Chrome(options=chrome_options, service=chromedriver_path)
 
@@ -203,8 +202,7 @@ def open_edge(context):
         edge_options.add_argument("--disable-gpu")
 
     # Add config browser options to edge options
-    for option in context.browser_options or []:
-        edge_options.add_argument(option)
+    edge_options = add_browser_options(context, edge_options)
 
     context.browser = webdriver.Edge(options=edge_options, service=edgedriver_path)
 
@@ -227,12 +225,21 @@ def open_firefox(context):
         firefox_options.add_argument("--headless")
 
     # Add config browser options to firefox options
-    for option in context.browser_options or []:
-        firefox_options.add_argument(option)
+    firefox_options = add_browser_options(context, firefox_options)
 
     context.browser = webdriver.Firefox(options=firefox_options, service=geckodriver_path)
 
     BrowserHandler.set_browser_size(context)
+
+
+def add_browser_options(context, browser_options):
+    try:
+        for option in context.browser_options or []:
+            browser_options.add_argument(option)
+    except AttributeError:
+        print("No config browser_options detected and the variable 'context.browser_options' is not defined")
+
+    return browser_options
 
 
 def start_browserstack(context):


### PR DESCRIPTION
- No longer necessary to define the 'context.browser_options' variable in _environment.py_ if you do not intend on using 'browser_options' in the config
- Updated required packages to the latest versions in setup.py
- Updated required packages to the latest versions in azure-pipelines.yml

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)