### PR TITLE
Axe report improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+10.2.0 / 2022-11-03
+===================
+- Added the ability to exclude elements when running Axe reports on a page. This is not a breaking change as the default is still running the report on the full page
+
 10.1.0 / 2022-11-02
 ===================
 - No longer necessary to define the 'context.browser_options' variable in _environment.py_ if you do not intend on using 'browser_options' in the config

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This package is located on PyPI: https://pypi.org/project/uitestcore/ - it can b
 The easiest way to include this package in your project is by adding it to your requirements.txt. 
 Here is an example of the line which should be added to this file, we recommend using a specific version but it's your call: 
 
-`uitestcore==10.0.0`
+`uitestcore==10.2.0`
 
 ### Deployment to PyPI
 PyPI deployment is configured in the release pipeline of the NHS.UK Azure Devops project. Any changes merged into master will be automatically deployed to PyPI, and any changes pushed to a branch starting with "test/" will be automatically deployed to TestPyPI.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.1.0",
+    version="10.2.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -100,11 +100,13 @@ class BrowserHandler:
                 shutil.move(source + file, destination)
 
     @staticmethod
-    def run_axe_accessibility_report(context):
+    def run_axe_accessibility_report(context, exclude=None):
         """
         Run Axe accessibility report on the current page and output a file containing violations if found
         :param context: the test context instance
+        :param exclude: specify which elements to exclude from the run, the default is None
         The context must include an instance of Axe (context.axe) and the Scenario name (context.scenario_name)
+        An example of exclude using CSS: {"exclude": [["#nhsuk-cookie-banner"], [".footer"]]}
         """
         try:
             context.scenario_name
@@ -116,7 +118,7 @@ class BrowserHandler:
         # Inject axe-core javascript into page
         context.axe.inject()
         # Run axe accessibility checks
-        axe_results = context.axe.run()
+        axe_results = context.axe.run(context=exclude)
         # Checks for violations and adds them to a text file if they exist
         if len(axe_results["violations"]) > 0:
             write_axe_violations_to_file(context, axe_results)


### PR DESCRIPTION
## Description
Added the ability to exclude elements when running Axe reports on a page. This is not a breaking change as the default is still running the report on the full page. To make use of this, pass in a JSON to the exclude parameter in the _run_axe_accessibility_report_ function.
An example of exclude using CSS: `{"exclude": [["#nhsuk-cookie-banner"], [".footer"]]}`

## Motivation and Context
This change allows a user to exclude certain elements from the Axe report such as a cookie banner, a header or a footer.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)