### PR TITLE
incorporate axe into framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-10.3.0 / 2022-11-18
+10.3.0 / 2022-11-22
 ===================
 - Axe-core is now fully integrated in to the uitestcore framework
     - No longer necessary to pip install _axe-selenium-python-nhsuk_ in your test pack, the framework handles this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+10.3.0 / 2022-11-18
+===================
+- Axe-core is now fully integrated in to the uitestcore framework
+    - No longer necessary to pip install axe-selenium-python in your test pack, the framework handles this
+    - No longer necessary to initialise Axe in your test pack, the framework handles this
+
 10.2.0 / 2022-11-03
 ===================
 - Added the ability to include/exclude elements when running Axe reports on a page. This is not a breaking change as the default is still running the report on the full page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 10.3.0 / 2022-11-18
 ===================
 - Axe-core is now fully integrated in to the uitestcore framework
-    - No longer necessary to pip install axe-selenium-python in your test pack, the framework handles this
+    - No longer necessary to pip install _axe-selenium-python-nhsuk_ in your test pack, the framework handles this
     - No longer necessary to initialise Axe in your test pack, the framework handles this
 
 10.2.0 / 2022-11-03

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.2.01",
+    version="10.3.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.2.0",
+    version="10.2.01",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -21,7 +21,8 @@ setup(
         "requests==2.28.1",
         "selenium==4.4.3",
         "six==1.16.0",
-        "urllib3==1.26.12"
+        "urllib3==1.26.12",
+        "axe-selenium-python-nhsuk"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/unit/utilities/test_browser_handler.py
+++ b/tests/unit/utilities/test_browser_handler.py
@@ -228,13 +228,6 @@ def test_move_screenshots_to_folder(mock_move, mock_path_exists, mock_listdir):
     mock_move.assert_any_call("screenshots/test4.png", "screenshots/test_folder")
 
 
-def test_run_axe_accessibility_report_no_axe_instance():
-    context = MockContext()
-
-    assert_that(calling(BrowserHandler.run_axe_accessibility_report).with_args(context), raises(AttributeError),
-                "An AttributeError should be raised when there is no context.axe value")
-
-
 @mock.patch("uitestcore.utilities.browser_handler.open_chrome")
 @mock.patch("uitestcore.utilities.browser_handler.open_edge")
 @mock.patch("uitestcore.utilities.browser_handler.start_browserstack")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -3,6 +3,7 @@ import os
 import platform
 import shutil
 from pathlib import Path
+from axe_selenium_python import Axe
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.firefox.service import Service as FirefoxService
@@ -105,7 +106,7 @@ class BrowserHandler:
         Run Axe accessibility report on the current page and output a file containing violations if found
         :param context: the test context instance
         :param element_filter: specify which elements to include/exclude from the run, the default is None
-        The context must include an instance of Axe (context.axe) and the Scenario name (context.scenario_name)
+        The context should include the Scenario name (context.scenario_name)
         An example of include using CSS: {"include": [["#nhsuk-cookie-banner"]]}
         An example of exclude using CSS: {"exclude": [["#nhsuk-cookie-banner"], [".footer"]]}
         """
@@ -113,8 +114,9 @@ class BrowserHandler:
             context.scenario_name
         except AttributeError:
             context.scenario_name = "No Scenario name passed to function"
-        if not context.axe:
-            raise AttributeError()
+
+        # Initialise and pass the driver/browser instance to the Axe class
+        context.axe = Axe(context.browser)
 
         # Inject axe-core javascript into page
         context.axe.inject()


### PR DESCRIPTION
## Description
Axe-core is now fully integrated in to the uitestcore framework
    - No longer necessary to pip install _axe-selenium-python-nhsuk_ in your test pack, the framework handles this
    - No longer necessary to initialise Axe in your test pack, the framework handles this

## Motivation and Context
Prior to this change, to run Axe-core you would need to pip install a git version of _axe-selenium-python_ and run `npm install` in your test pack and then initialise the Axe class. The framework would then handle the running and reporting of the initialised Axe class. 
Now, the framework installs the _axe-selenium-python-nhsuk_ PyPi package during the setup/install. The framework also initialises the Axe class as well the running and reporting. This reduces the amount of setup you would need to do in your own test pack.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)