### PR TITLE
'For_element_to_have attribute' method bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+10.3.1 / 2022-12-08
+===================
+- Resolved string formatting issue which prevented the 'for_element_to_have_attribute' method from working
+
 10.3.0 / 2022-11-22
 ===================
 - Axe-core is now fully integrated in to the uitestcore framework

--- a/docs/contributing/unittesting.md
+++ b/docs/contributing/unittesting.md
@@ -7,6 +7,7 @@ We require a minimum coverage rate of 95%
 
 ## How to run
 **Requires:** [pytest](https://pypi.org/project/pytest/)
+**Requires:** [pytest-cov](https://pypi.org/project/pytest-cov/)
 
 In the root of the project, run the following command:
 ``` bash

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.3.0",
+    version="10.3.1",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/uitestcore/waiter.py
+++ b/uitestcore/waiter.py
@@ -75,7 +75,7 @@ class Waiter:
         :param attribute_name: the name of the attribute whose value you want e.g. 'type'
         :param expected_attribute_value: the string value which is expected for the attribute
         """
-        self.logger.info("Waiting for %s to be have attribute %s=$s", page_element, attribute_name,
+        self.logger.info("Waiting for %s to be have attribute %s=%s", page_element, attribute_name,
                          expected_attribute_value)
         WebDriverWait(self.driver, self.wait_time).until(ElementHasAttribute(self.find, page_element,
                                                                              attribute_name, expected_attribute_value))


### PR DESCRIPTION

## Description
If you use the 'for_element_to_have_attribute' method in waiter.py in your tests, and the element with the expected attribute and value is found in the DOM, an exception will be thrown. This exception occurs when the logger attempts to write the log message on line 78. This is because it's trying to pass in more args to the string formattr than you have placeholders in the string; the final placeholder being $s rather than %s

I have also added the missing dependency to the unittesting.md file.

## Related Issue
https://github.com/nhsuk/ui-test-core/issues/40

## Motivation and Context
Resolves a bug, allowing use of this method in our tests.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [N] New and/or updated tests
_Existing tests do not cover any logging messages - one to consider going forward?_
- [Y] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
- [Y] [Linting](../docs/contributing/linting.md) score remains above threshold. 
_Please note that the existing code does not pass the 9.5 minimum score - it scores 9.0 (when run locally)_
- [ Y] Changes log in [`CHANGELOG`](../CHANGELOG.md)