### PR TITLE
Axe improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
+10.5.0 / 2024-01-10
+===================
+- Added the ability to specify which _rules_ to use when running Axe reports on a page. This is not a breaking change as the default is still running the report on the full page using default rules
+  - An example of filtering rules using tags: rule_filter={"runOnly": ['wcag2a', 'wcag2aa']} - this will run WCAG
+             2.0 Level A and Level AA rules only
+- Full Axe accessibility report is now returned regardless of whether violations are found
+
 10.4.1 / 2023-08-18
 ===================
 - Updated Readme to cover work around for using 10.4.0 with Chromium in Linux
 
 10.4.0 / 2023-08-16
 ===================
-- Updated Selenium to version 4.11.2 to enable Chrome For Testing support.
+- Updated Selenium to version 4.11.2 to enable Chrome For Testing support
 
 10.3.2 / 2023-06-23
 ===================

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.5.20240110",
+    version="10.5.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.4.1",
+    version="10.5.20240110",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -98,14 +98,21 @@ class BrowserHandler:
                 shutil.move(source + file, destination)
 
     @staticmethod
-    def run_axe_accessibility_report(context, element_filter=None):
+    def run_axe_accessibility_report(context, element_filter=None, rule_filter=None):
         """
-        Run Axe accessibility report on the current page and output a file containing violations if found
-        :param context: the test context instance
-        :param element_filter: specify which elements to include/exclude from the run, the default is None
-        The context should include the Scenario name (context.scenario_name)
-        An example of include using CSS: {"include": [["#nhsuk-cookie-banner"]]}
-        An example of exclude using CSS: {"exclude": [["#nhsuk-cookie-banner"], [".footer"]]}
+        Run Axe accessibility report on the current page and output a file containing violations if found. Returns the
+        full Axe accessibility report regardless of whether violations are found.
+
+        :param context: the test context instance. The context should include the Scenario name (context.scenario_name).
+        :param element_filter: specify which elements to include/exclude from the run, the default is None. An example
+            of include using CSS: element_filter={"include": [["#nhsuk-cookie-banner"]]}. An example of exclude using
+            CSS: element_filter={"exclude": [["#nhsuk-cookie-banner"], [".footer"]]}. For more details about this
+            parameter, see https://github.com/dequelabs/axe-core/blob/master/doc/API.md#context-parameter.
+        :param rule_filter: specify which rules to use in the run, the default is None (use the default rules). An
+            example of filtering rules using tags: rule_filter={"runOnly": ['wcag2a', 'wcag2aa']} - this will run WCAG
+            2.0 Level A and Level AA rules only. For more details about this parameter, see
+            https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter.
+        :return: the full Axe accessibility report for the page tested.
         """
         try:
             context.scenario_name
@@ -118,10 +125,11 @@ class BrowserHandler:
         # Inject axe-core javascript into page
         context.axe.inject()
         # Run axe accessibility checks
-        axe_results = context.axe.run(context=element_filter)
+        axe_results = context.axe.run(context=element_filter, options=rule_filter)
         # Checks for violations and adds them to a text file if they exist
         if len(axe_results["violations"]) > 0:
             write_axe_violations_to_file(context, axe_results)
+        return axe_results
 
 
 def write_axe_violations_to_file(context, results):


### PR DESCRIPTION
<!--
Thanks for wanting to contribute to this repository.

In order for the changes to be integrated into the repo with as little friction
as possible please follow the guidance here. This includes completing all
sections as fully as possible.
Prior to creating a Pull Request, please ensure there is an open issue for the
changes you wish to make. This will provide visibility to others early in the
process. Potentially other people will wish to help out. It also allows us to
validate the change is inline with our vision for the product.

Provide a general summary of your changes in the Title
-->

## Description
- Added the ability to specify which _rules_ to use when running Axe reports on a page. This is not a breaking change as the default is still running the report on the full page using default rules
  - An example of filtering rules using tags: rule_filter={"runOnly": ['wcag2a', 'wcag2aa']} - this will run WCAG
             2.0 Level A and Level AA rules only
- Full Axe accessibility report is now returned regardless of whether violations are found

## Motivation and Context
- User can filter the Axe accessibility report using _rules_ in addition to _including/excluding_ elements
- axe-core updated from version 4.6.2 > 4.8.2

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] New and/or updated tests
- [x] All the [unit tests](../docs/contributing/unittesting.md) are passing. 
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] [Linting](../docs/contributing/linting.md) score remains above threshold.
_This is enforced automatically as part of the pull request, but we'd appreciate you running locally first._
- [x] Changes log in [`CHANGELOG`](../CHANGELOG.md)