### PR TITLE
UiTestCore - Fix concurrency issue with BrowserHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-10.6.0
+10.6.0 / 2024-07-29
 ===================
 - Fix for concurrency issue in taking and moving screenshots
   - Updated BrowserHandler.take_screenshot so that it will store the name of the file that has been saved in a property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+10.6.0
+===================
+- Fix for concurrency issue in taking and moving screenshots
+  - Updated BrowserHandler.take_screenshot so that it will store the name of the file that has been saved in a property
+      on the class itself.
+  - Updated BrowserHandler.move_screenshots_to_folder to take an optional parameter, file_names, that (if provided) will
+      override the default behaviour of moving all .png files from the source to the target folder, and instead will 
+      only move files matching the file_names from the source to the target folder.
+
+
 10.5.0 / 2024-01-10
 ===================
 - Added the ability to specify which _rules_ to use when running Axe reports on a page. This is not a breaking change as the default is still running the report on the full page using default rules

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="uitestcore",
-    version="10.5.0",
+    version="10.6.0",
     description="Package providing common functionality for UI automation test packs",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/utilities/test_browser_handler.py
+++ b/tests/utilities/test_browser_handler.py
@@ -70,13 +70,15 @@ class MockLogger:
         return MockLogger(False, True)
 
 
-class MockDriver(object):
-    def __init__(self, window_width, window_height, scroll_height, save_screenshot_success=True, save_test_file=False):
+class MockDriver:
+
+    save_test_file = False
+
+    def __init__(self, window_width, window_height, scroll_height, save_screenshot_success=True):
         self.window_width = window_width
         self.window_height = window_height
         self.scroll_height = scroll_height
         self.save_screenshot_success = save_screenshot_success
-        self.save_test_file = save_test_file
         self.screenshot_filename = ""
         self.num_resizes = 0
 
@@ -97,7 +99,7 @@ class MockDriver(object):
     def save_screenshot(self, file_name):
         self.screenshot_filename = file_name
         if self.save_test_file:
-            with open(file_name, "w+") as file:
+            with open(file_name, "w+", encoding="UTF-8") as file:
                 file.write("Test file content")
         return self.save_screenshot_success
 
@@ -307,7 +309,8 @@ def test_move_screenshots_to_folder_with_file_names(mock_move, mock_path_exists,
 
 def test_take_and_move_screenshots_to_folder():
     # This is more of an integration test, validating the combination of take_screenshot and move_screenshots_to_folder.
-    driver = MockDriver(1024, 768, 2000, True, True)
+    driver = MockDriver(1024, 768, 2000, True)
+    driver.save_test_file = True # Set the mock so that it will save a real file.
 
     # take_screenshot
     result = BrowserHandler.take_screenshot(driver, "test_file_name")

--- a/uitestcore/utilities/browser_handler.py
+++ b/uitestcore/utilities/browser_handler.py
@@ -17,6 +17,8 @@ class BrowserHandler:
     This class performs any necessary tasks related to the browser
     """
 
+    saved_screenshot_file_names = []
+
     @staticmethod
     def set_browser_size(context):
         """
@@ -44,8 +46,8 @@ class BrowserHandler:
         # Check if Maximize Browser Flag has been activated
         BrowserHandler.set_browser_size(context)
 
-    @staticmethod
-    def take_screenshot(driver, description):
+    @classmethod
+    def take_screenshot(cls, driver, description):
         """
         Save a screenshot of the browser window - should be used after a test fails
         :param driver: the browser driver
@@ -77,13 +79,17 @@ class BrowserHandler:
         if scroll_height > window_height:
             driver.set_window_size(window_width, window_height)
 
+        if result:
+            cls.saved_screenshot_file_names.append(file_name)
         return result
 
     @staticmethod
-    def move_screenshots_to_folder(folder_name):
+    def move_screenshots_to_folder(folder_name, file_names=None):
         """
         Create a new folder and move all screenshots from the root screenshot folder into it (to be run at end of test)
         :param folder_name: the name of the folder into which the screenshots should be moved
+        :param file_names: (optional) the name of the files to be moved. Default None. If None, then move any files
+        ending with .png. Otherwise, move any files that match the given saved_screenshot_file_names.
         """
         folder_name = remove_invalid_characters(folder_name)
         source = f"{SCREENSHOTS_PATH}/"
@@ -94,8 +100,12 @@ class BrowserHandler:
             os.makedirs(destination)
 
         for file in files:
-            if file.endswith(".png"):
-                shutil.move(source + file, destination)
+            if file_names is None:
+                if file.endswith(".png"):
+                    shutil.move(source + file, destination)
+            else:
+                if any(file in f for f in file_names):
+                    shutil.move(source + file, destination)
 
     @staticmethod
     def run_axe_accessibility_report(context, element_filter=None, rule_filter=None):


### PR DESCRIPTION
## Description
- In take_screenshot, save the name of the file to the class so that it can be accessed again.
- In move_screenshots_to_folder, accept and optional parameter with a list of file names. If the list of file names is given, then only move files matching this file name. This will solve any concurrency issues as this is stricter than simply moving every file that is a .png file.
- Update the unit tests, and add coverage for this new functionality.

## Related Issue
[BUG #49 ](https://github.com/nhsuk/ui-test-core/issues/49)

## Motivation and Context
This allows the `move_screenshots_to_folder` method to be more specific about which files it is moving (as opposed to moving any file with any name of type .png).